### PR TITLE
feat: Add new ways to fetch git date

### DIFF
--- a/src/GitInfo.php
+++ b/src/GitInfo.php
@@ -58,7 +58,7 @@ class GitInfo implements GitInfoInterface {
    */
   public function getDate() {
     @trigger_error('GitInfoInterface::getDate() is deprecated in eiriksm/gitinfo:4.1.0 and is removed from eiriksm/gitinfo:5.0.0. Use ::getRfc3339Date() or ::getCustomDate().', E_USER_DEPRECATED);
-    return $this->getCustomDate('Y-m-d H:m:s');
+    return $this->getCustomDate('Y-m-d H:m:s') ?? FALSE;
   }
 
   /**

--- a/src/GitInfo.php
+++ b/src/GitInfo.php
@@ -39,7 +39,10 @@ class GitInfo implements GitInfoInterface {
   }
 
   /**
-   * Fetches the date from
+   * Fetches the date from the git log.
+   * 
+   * @return \DateTime|null
+   *   Time object in UTC or null if the date could not be fetched.
    */
   protected function getGitDate() {
     if (!$date = $this->execAndTrim(['log', '-n1', '--pretty=%ci', 'HEAD'])) {

--- a/src/GitInfo.php
+++ b/src/GitInfo.php
@@ -50,7 +50,7 @@ class GitInfo implements GitInfoInterface {
     }
     $commit_date = new \DateTime($date);
     $commit_date->setTimezone(new \DateTimeZone('UTC'));
-    return $commit_date
+    return $commit_date;
   }
 
   /**

--- a/src/GitInfo.php
+++ b/src/GitInfo.php
@@ -39,17 +39,40 @@ class GitInfo implements GitInfoInterface {
   }
 
   /**
-   * {@inheritdoc}
+   * Fetches the date from
    */
-  public function getDate() {
+  protected function getGitDate() {
     if (!$date = $this->execAndTrim(['log', '-n1', '--pretty=%ci', 'HEAD'])) {
-      return FALSE;
+      return NULL;
     }
     $commit_date = new \DateTime($date);
     $commit_date->setTimezone(new \DateTimeZone('UTC'));
-    return $commit_date->format('Y-m-d H:m:s');
+    return $commit_date
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function getDate() {
+    @trigger_error('GitInfoInterface::getDate() is deprecated in eiriksm/gitinfo:4.1.0 and is removed from eiriksm/gitinfo:5.0.0. Use ::getIsoDate() or ::getCustomDate().', E_USER_DEPRECATED);
+    return $this->getCustomDate('Y-m-d H:m:s');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function geIsotDate() {
+    return $this->getGitDate()->format('c');
+  }
+
+  
+  /**
+   * {@inheritdoc}
+   */
+  public function getCustomDate(string $format) {
+    return $this->getGitDate()->format($format);
+  }
+  
   /**
    * Helper to make sure we trim the output.
    *

--- a/src/GitInfo.php
+++ b/src/GitInfo.php
@@ -61,16 +61,16 @@ class GitInfo implements GitInfoInterface {
   /**
    * {@inheritdoc}
    */
-  public function geIsotDate() {
-    return $this->getGitDate()->format('c');
+  public function getRfc3339Date() {
+    return $this->getCustomDate(\DateTimeInterface::RFC3339_EXTENDED);
   }
 
-  
   /**
    * {@inheritdoc}
    */
   public function getCustomDate(string $format) {
-    return $this->getGitDate()->format($format);
+    $date = $this->getGitDate();
+    return $date ? $date->format($format) : NULL;
   }
   
   /**

--- a/src/GitInfo.php
+++ b/src/GitInfo.php
@@ -54,7 +54,7 @@ class GitInfo implements GitInfoInterface {
    * {@inheritdoc}
    */
   public function getDate() {
-    @trigger_error('GitInfoInterface::getDate() is deprecated in eiriksm/gitinfo:4.1.0 and is removed from eiriksm/gitinfo:5.0.0. Use ::getIsoDate() or ::getCustomDate().', E_USER_DEPRECATED);
+    @trigger_error('GitInfoInterface::getDate() is deprecated in eiriksm/gitinfo:4.1.0 and is removed from eiriksm/gitinfo:5.0.0. Use ::getRfc3339Date() or ::getCustomDate().', E_USER_DEPRECATED);
     return $this->getCustomDate('Y-m-d H:m:s');
   }
 

--- a/src/GitInfoInterface.php
+++ b/src/GitInfoInterface.php
@@ -34,7 +34,7 @@ interface GitInfoInterface {
    * Gets the date of the latest commit.
    * 
    * @deprecated in eiriksm/gitinfo:4.1.0 and is removed from eiriksm/gitinfo:5.0.0.
-   *   Use ::getIsoDate() or ::getCustomDate().
+   *   Use ::getRfc3339Date() or ::getCustomDate().
    *
    * @return string|false
    *   A date string, or FALSE if there was a problem.

--- a/src/GitInfoInterface.php
+++ b/src/GitInfoInterface.php
@@ -14,7 +14,7 @@ interface GitInfoInterface {
    *
    * Like "e7ccadcb".
    *
-   * @return string|bool
+   * @return string|false
    *   The hash string or FALSE if there was an error (like for example, there
    *   is no git repo.
    */
@@ -32,11 +32,40 @@ interface GitInfoInterface {
 
   /**
    * Gets the date of the latest commit.
+   * 
+   * @deprecated in eiriksm/gitinfo:4.1.0 and is removed from eiriksm/gitinfo:5.0.0.
+   *   Use ::getIsoDate() or ::getCustomDate().
    *
-   * @return string|bool
+   * @return string|false
    *   A date string, or FALSE if there was a problem.
    */
   public function getDate();
+
+
+  /**
+   * Gets the date of the latest commit in RFC#3339 format.
+   * 
+   * @see DateTimeInterface::RFC3339_EXTENDED
+   * 
+   * @return string|null
+   *   A date string, or NULL if there was a problem.
+   */
+  public function getRfc3339Date();
+
+  
+  /**
+   * Gets the date of the latest commit in the specified format.
+   * 
+   * @see https://www.php.net/manual/en/datetime.format.php
+   * 
+   * @param string $format
+   *   Format accepted by <a href="https://www.php.net/manual/en/datetime.format.php">DateTimeInterface::format()</a>.
+   * 
+   * @return string|null
+   *   A date string, or NULL if there was a problem.
+   */
+  public function getCustomDate(string $format);
+  
 
   /**
    * Gets the assembled application version string.

--- a/tests/src/GitInfoTest.php
+++ b/tests/src/GitInfoTest.php
@@ -38,6 +38,16 @@ class GitInfoTest extends TestCase {
     $this->assertNotFalse($i->getDate());
   }
 
+  public function testCustomDate() {
+    $i = new GitInfo();
+    $this->assertNotNull($i->getCustomDate('U'));
+  }
+
+  public function testRfcDate() {
+    $i = new GitInfo();
+    $this->assertNotNull($i->getRfc3339Date('U'));
+  }
+
   public function testBadDate() {
     $i = $this->getBadGit();
     $this->assertFalse($i->getDate());

--- a/tests/src/GitInfoTest.php
+++ b/tests/src/GitInfoTest.php
@@ -45,7 +45,7 @@ class GitInfoTest extends TestCase {
 
   public function testRfcDate() {
     $i = new GitInfo();
-    $this->assertNotNull($i->getRfc3339Date('U'));
+    $this->assertNotNull($i->getRfc3339Date());
   }
 
   public function testBadDate() {


### PR DESCRIPTION
This deprecates the default `GitInfoInterface::getDate()` as it uses a non-standard date format which does include time information and at the same time does not include any timezone information.

As replacements 2 alternatives are added:
- `::getRfc3339Date()` returns the date in a modern standard format [defined in RFC3339](http://www.faqs.org/rfcs/rfc2822.html).
- `::getCustomDate()` allows specifying any custom format from the user.